### PR TITLE
Lockdown version of nan

### DIFF
--- a/node_modules/nan/package.json
+++ b/node_modules/nan/package.json
@@ -56,13 +56,34 @@
     "xtend": "~4.0.0"
   },
   "license": "MIT",
+  "gitHead": "550efb5dde5cb6bf79db87ab48dce850e56e971a",
   "bugs": {
     "url": "https://github.com/rvagg/nan/issues"
   },
-  "readme": "ERROR: No README data found!",
   "homepage": "https://github.com/rvagg/nan",
   "_id": "nan@1.7.0",
   "_shasum": "755b997404e83cbe7bc08bc3c5c56291bce87438",
-  "_from": "nan@^1.7.0",
+  "_from": "nan@>=1.7.0 <1.8.0",
+  "_npmVersion": "2.5.1",
+  "_nodeVersion": "0.12.0",
+  "_npmUser": {
+    "name": "kkoopa",
+    "email": "bbyholm@abo.fi"
+  },
+  "maintainers": [
+    {
+      "name": "rvagg",
+      "email": "rod@vagg.org"
+    },
+    {
+      "name": "kkoopa",
+      "email": "bbyholm@abo.fi"
+    }
+  ],
+  "dist": {
+    "shasum": "755b997404e83cbe7bc08bc3c5c56291bce87438",
+    "tarball": "http://registry.npmjs.org/nan/-/nan-1.7.0.tgz"
+  },
+  "directories": {},
   "_resolved": "https://registry.npmjs.org/nan/-/nan-1.7.0.tgz"
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "node": ">=0.11.14"
   },
   "dependencies": {
-    "nan": "*"
+    "nan": "~1.7.0"
   },
   "devDependencies": {},
   "optionalDependencies": {}


### PR DESCRIPTION
Fixes the error I was experiencing in #7 . The 2.0 release of nan contains different methods which breaks pdf-fill-form.