### PR TITLE
Support additional FormField types, add id support.

### DIFF
--- a/src/NodePoppler.cc
+++ b/src/NodePoppler.cc
@@ -148,7 +148,6 @@ WriteFieldsParams v8ParamsToCpp(const v8::FunctionCallbackInfo<Value>& args) {
 QBuffer *writePdfFields(struct WriteFieldsParams params) {
 
   ostringstream ss;
- 
   // If source file does not exist, throw error and return false
   if (!fileExists(params.sourcePdfFileName)) {
     ss << "File \"" << params.sourcePdfFileName << "\" does not exist";
@@ -164,14 +163,21 @@ QBuffer *writePdfFields(struct WriteFieldsParams params) {
 
   // Fill form
   int n = document->numPages();
-
+  stringstream idSS;
   for (int i = 0; i < n; i += 1) {
     Poppler::Page *page = document->page(i);
 
     foreach (Poppler::FormField *field, page->formFields()) {
       string fieldName = field->fullyQualifiedName().toStdString();
-      if (!field->isReadOnly() && field->isVisible() && params.fields.count(fieldName)) {
-
+      // Support writing fields by both fieldName and id.
+      // If fieldName is not present in params, try id.
+      if (params.fields.count(fieldName) == 0) {
+        idSS << field->id();
+        fieldName = idSS.str();
+        idSS.str("");
+        idSS.clear();
+      }
+      if (!field->isReadOnly() && field->isVisible() && params.fields.count(fieldName) ) {
         // Text
         if (field->type() == Poppler::FormField::FormText) {
           Poppler::FormFieldText *textField = (Poppler::FormFieldText *) field;
@@ -195,11 +201,11 @@ QBuffer *writePdfFields(struct WriteFieldsParams params) {
             }
           }
         }
- 
+
         // Button
+        // ! TODO ! Note. Poppler doesn't support checkboxes with hashtag names (aka using exportValue).
         if (field->type() == Poppler::FormField::FormButton) {
           Poppler::FormFieldButton *buttonField = (Poppler::FormFieldButton *) field;
-
           if (params.fields[fieldName].compare("true") == 0) {
             buttonField->setState(true);
           }
@@ -275,16 +281,16 @@ NAN_METHOD(ReadSync) {
         obj->Set(NanNew<String>("name"), NanNew<String>(field->fullyQualifiedName().toStdString()));
         obj->Set(NanNew<String>("page"), NanNew<Number>(i));
 
-        // ! TODO ! Now supports values only for "checkbox" and "text". Note. Poppler doesn't support checkboxes with hashtag names (aka using exportValue).
+        // ! TODO ! Note. Poppler doesn't support checkboxes with hashtag names (aka using exportValue).
         string fieldType;
-        Local<Array> choiceArray = NanNew<Array>();
         // Set default value undefined
         obj->Set(NanNew<String>("value"), NanUndefined());
         Poppler::FormFieldButton *myButton;
         Poppler::FormFieldChoice *myChoice;
-        
+
+        obj->Set(NanNew<String>("id"), NanNew<Number>(field->id()));
         switch (field->type()) {
-          
+
           // FormButton
           case Poppler::FormField::FormButton:
             myButton = (Poppler::FormFieldButton *)field;
@@ -307,6 +313,7 @@ NAN_METHOD(ReadSync) {
 
           // FormChoice
           case Poppler::FormField::FormChoice: {
+            Local<Array> choiceArray = NanNew<Array>();
             myChoice = (Poppler::FormFieldChoice *)field;
             QStringList possibleChoices = myChoice->choices();
             for (int i = 0; i < possibleChoices.size(); i++) {


### PR DESCRIPTION
1. Add support for FormChoice fields
 * On read, read all possible choices from field and return to user in `choices` array
 * On write, write freeform text if field is editable, or select provided field from possible choices, if present
2. Relax FormButton subtype checks
 * I was able to set radio fields by removing the CheckBox only check
3. Add id support
 * On read, return `id` of every field alongside `type`
 * On write, if field id matches the name of a param, write that param's value to the PDF.