### PR TITLE
Added QT5 Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ PDF Fill Form (**pdf-fill-form**) is Node.js native C++ library for filling PDF 
 Libary uses internally Poppler QT4 for PDF form reading and filling. Cairo is used for PDF creation from page images (when parameter { "save": "imgpdf" } is used). 
 ##Features
 
-* __NEW version 2.0.0__: Updated nan library to version 2.4.0. Now __pdf-fill-form__ works also with all latest node.js versions. Tested using 0.12.0, v4.4.7, v5.2.0, v6.3.0
+* __NEW version 2.0.0__: Updated nan library to version 2.4.0. Now __pdf-fill-form__ works also with all latest node.js versions. Tested using 0.12.0, v4.4.7, v5.2.0, v6.3.0, v6.8.0
 
 * Supports reading and writing the following PDF form field types: TextField and Checkbox 
 * You can write following files:
@@ -87,7 +87,7 @@ Use parameter { "save": "imgpdf" }
 Preferable method to install library dependencies is via [Homebrew](http://brew.sh/)
 
 ```
-$ brew install qt4 cairo poppler --with-qt4
+$ brew install qt5 cairo poppler --with-qt5
 ```
 After dependencies are successfully installed, you can install the library:
 

--- a/README.md
+++ b/README.md
@@ -122,14 +122,6 @@ $ sudo apt-get install libcairo2-dev
 $ sudo apt-get -t wheezy-backports install libpoppler-qt5-dev 
 $ npm install pdf-fill-form
 ```
-### TravisCI
-```
-addons:
-  apt:
-    packages:
-      - libpoppler-qt5-dev
-      - libcairo2-dev
-```
 
 ##Todo
 * Tests

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ $ npm install pdf-fill-form
 
 ###Linux - Ubuntu (trusty)
 ```
-$ sudo apt-get install libpoppler-qt4-dev libcairo2-dev
+$ sudo apt-get install libpoppler-qt5-dev libcairo2-dev
 $ npm install pdf-fill-form
 ```
 ###Linux - Debian (wheezy)
@@ -113,7 +113,7 @@ Then install packages
 
 ```
 $ sudo apt-get install libcairo2-dev
-$ sudo apt-get -t wheezy-backports install libpoppler-qt4-dev 
+$ sudo apt-get -t wheezy-backports install libpoppler-qt5-dev 
 $ npm install pdf-fill-form
 ```
 ### TravisCI
@@ -121,7 +121,7 @@ $ npm install pdf-fill-form
 addons:
   apt:
     packages:
-      - libpoppler-qt4-dev
+      - libpoppler-qt5-dev
       - libcairo2-dev
 ```
 

--- a/README.md
+++ b/README.md
@@ -116,6 +116,15 @@ $ sudo apt-get install libcairo2-dev
 $ sudo apt-get -t wheezy-backports install libpoppler-qt4-dev 
 $ npm install pdf-fill-form
 ```
+### TravisCI
+```
+addons:
+  apt:
+    packages:
+      - libpoppler-qt4-dev
+      - libcairo2-dev
+```
+
 ##Todo
 * Tests
 * Refactoring

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <img src="http://res.cloudinary.com/tpisto/image/upload/v1428317033/pdf-fill-form-logo_rlfj7o.png" width="400"><br/>
 PDF Fill Form (**pdf-fill-form**) is Node.js native C++ library for filling PDF forms. Created PDF file is returned back as Node.js Buffer object for further processing or saving - *whole process is done in memory*. Library offers methods to return filled PDF also as PDF file where pages are converted to images.
 
-Libary uses internally Poppler QT4 for PDF form reading and filling. Cairo is used for PDF creation from page images (when parameter { "save": "imgpdf" } is used). 
+Libary uses internally Poppler QT5 for PDF form reading and filling. Cairo is used for PDF creation from page images (when parameter { "save": "imgpdf" } is used). 
 ##Features
 
 * __NEW version 2.0.0__: Updated nan library to version 2.4.0. Now __pdf-fill-form__ works also with all latest node.js versions. Tested using 0.12.0, v4.4.7, v5.2.0, v6.3.0, v6.8.0

--- a/binding.gyp
+++ b/binding.gyp
@@ -3,8 +3,8 @@
         {
             "target_name": "pdf_fill_form",
             "variables": {
-                "myLibraries": "cairo poppler",
-                "myIncludes": "QtCore"
+                "myLibraries": "cairo poppler-qt5",
+                "myIncludes": ""
             },            
             "sources": [
                 "src/pdf-fill-form.cc",

--- a/binding.gyp
+++ b/binding.gyp
@@ -3,8 +3,7 @@
         {
             "target_name": "pdf_fill_form",
             "variables": {
-                "myLibraries": "cairo poppler-qt5",
-                "myIncludes": ""
+                "myLibraries": "cairo poppler-qt5"
             },            
             "sources": [
                 "src/pdf-fill-form.cc",
@@ -14,7 +13,7 @@
             'cflags!': [ '-fno-exceptions' ],
             'cflags_cc!': [ '-fno-exceptions' ],
             "cflags": [
-                "<!@(pkg-config --cflags <(myLibraries) <(myIncludes))"
+                "<!@(pkg-config --cflags <(myLibraries))"
             ],
             "xcode_settings": {
                 'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
@@ -23,7 +22,7 @@
                     '-std=c++11',
                     '-stdlib=libc++',                
                     "-fexceptions",
-                    "<!@(pkg-config --cflags <(myLibraries) <(myIncludes))"
+                    "<!@(pkg-config --cflags <(myLibraries))"
                 ]
             },
             "libraries": [

--- a/binding.gyp
+++ b/binding.gyp
@@ -3,7 +3,7 @@
         {
             "target_name": "pdf_fill_form",
             "variables": {
-                "myLibraries": "cairo poppler-qt4",
+                "myLibraries": "cairo poppler-qt5",
                 "myIncludes": "QtCore"
             },            
             "sources": [

--- a/binding.gyp
+++ b/binding.gyp
@@ -3,7 +3,7 @@
         {
             "target_name": "pdf_fill_form",
             "variables": {
-                "myLibraries": "cairo poppler-qt5",
+                "myLibraries": "cairo poppler",
                 "myIncludes": "QtCore"
             },            
             "sources": [

--- a/src/NodePoppler.cc
+++ b/src/NodePoppler.cc
@@ -6,8 +6,8 @@
 #include <stdlib.h>
 #include <stdio.h>
 
-#include <poppler/qt4/poppler-form.h>
-#include <poppler/qt4/poppler-qt4.h>
+#include <poppler/qt5/poppler-form.h>
+#include <poppler/qt5/poppler-qt5.h>
 
 #include <cairo/cairo.h>
 #include <cairo/cairo-pdf.h>


### PR DESCRIPTION
I'll update the docs as well.
This fixes issues if you are running MacOS Sierra and installing QT5 and new Poppler.

I'm having lots of trouble getting qt5 working on travis-ci.