### PR TITLE
add support of jessie distribution and node v6.9.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Libary uses internally Poppler QT5 for PDF form reading and filling. Cairo is us
 
 * __NEW version 3.0.0__: Updated QT library to version 5 (by Rob Davarnia @robdvr). 
 
-* Version 2.0.0__: Updated nan library to version 2.4.0. Now __pdf-fill-form__ works also with all latest node.js versions. Tested using 0.12.0, v4.4.7, v5.2.0, v6.3.0, v6.8.0
+* Version 2.0.0__: Updated nan library to version 2.4.0. Now __pdf-fill-form__ works also with all latest node.js versions. Tested using 0.12.0, v4.4.7, v5.2.0, v6.3.0, v6.8.0, v6.9.1
 
 * Supports reading and writing the following PDF form field types: TextField and Checkbox 
 * You can write following files:

--- a/README.md
+++ b/README.md
@@ -110,19 +110,22 @@ brew link --force qt5
 $ sudo apt-get install libpoppler-qt5-dev libcairo2-dev
 $ npm install pdf-fill-form
 ```
-###Linux - Debian (wheezy)
-We need newer Poppler library than the current in Wheezy distribution: 
+###Linux - Debian (jessie)
 
+To be sure to have the required packages, re-synchronize the package index files from their sources :
 ```
-$ sudo add-apt-repository "deb http://http.debian.net/debian wheezy-backports main"     
 $ sudo apt-get update
 ```
-Then install packages
+Then install packages :
 
 ```
-$ sudo apt-get install libcairo2-dev
-$ sudo apt-get -t wheezy-backports install libpoppler-qt5-dev 
+$ sudo apt-get install libcairo2-dev libpoppler-qt5-dev 
 $ npm install pdf-fill-form
+```
+
+I mostly recommand to install this package to have better support with fonts :
+```
+$ sudo apt-get install poppler-data
 ```
 
 ##Todo

--- a/binding.gyp
+++ b/binding.gyp
@@ -15,6 +15,14 @@
             "cflags": [
                 "<!@(pkg-config --cflags <(myLibraries))"
             ],
+            'conditions': [
+                ['OS=="linux"', {'cflags': [
+                    "-isystem /usr/include/x86_64-linux-gnu/qt5",
+                    "-isystem /usr/include/x86_64-linux-gnu/qt5/QtCore",
+                    "-isystem /usr/include/x86_64-linux-gnu/qt5/QtGui",
+                    "-lQt5Core"
+                    "-lQt5Gui"]}]
+            ],
             "xcode_settings": {
                 'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
                 "OTHER_CFLAGS": [


### PR DESCRIPTION
Hi,

The package [libpoppler-qt5-dev](https://packages.debian.org/jessie/libpoppler-qt5-dev) doesn't exist on any sources of **wheezy** distribution. So, I upgrade the librairie for **jessie**.
Also, I add some **cflags** for linux compilation to support **qt5**. Without I had errors of missing files.
*Warning, I didn't check it on ubuntu.*

Bye,
Fabrice.