### PR TITLE
Fix qt5 include paths on linux

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -3,7 +3,8 @@
         {
             "target_name": "pdf_fill_form",
             "variables": {
-                "myLibraries": "cairo poppler-qt5"
+                "myLibraries": "cairo poppler-qt5",
+                "osLibraries": ""
             },            
             "sources": [
                 "src/pdf-fill-form.cc",
@@ -13,15 +14,13 @@
             'cflags!': [ '-fno-exceptions' ],
             'cflags_cc!': [ '-fno-exceptions' ],
             "cflags": [
-                "<!@(pkg-config --cflags <(myLibraries))"
+                "<!@(pkg-config --cflags <(osLibraries) <(myLibraries))"
             ],
             'conditions': [
-                ['OS=="linux"', {'cflags': [
-                    "-isystem /usr/include/x86_64-linux-gnu/qt5",
-                    "-isystem /usr/include/x86_64-linux-gnu/qt5/QtCore",
-                    "-isystem /usr/include/x86_64-linux-gnu/qt5/QtGui",
-                    "-lQt5Core"
-                    "-lQt5Gui"]}]
+              ['OS=="linux"', {
+                "variables": {
+                  "osLibraries": "Qt5Core Qt5Gui"
+                }}]
             ],
             "xcode_settings": {
                 'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
@@ -30,17 +29,15 @@
                     '-std=c++11',
                     '-stdlib=libc++',                
                     "-fexceptions",
-                    "<!@(pkg-config --cflags <(myLibraries))"
+                    "<!@(pkg-config --cflags <(osLibraries) <(myLibraries))"
                 ]
             },
             "libraries": [
-                "<!@(pkg-config --libs <(myLibraries))"
+                "<!@(pkg-config --libs <(osLibraries) <(myLibraries))"
             ],
             "include_dirs" : [
                "<!(node -e \"require('nan')\")"
             ]
-
-
         }
     ]
 }


### PR DESCRIPTION
With this change, the package will at least build on different architectures on Linux. There is bound to be an even better way to figure out these paths independent of the platform, though.