### PR TITLE
Adding caption property to radio fields on ReadSync

### DIFF
--- a/src/NodePoppler.cc
+++ b/src/NodePoppler.cc
@@ -354,7 +354,10 @@ NAN_METHOD(ReadSync) {
                 fieldType = "checkbox";
                 Nan::Set(obj, Nan::New<String>("value").ToLocalChecked(), Nan::New<Boolean>(myButton->state()));
                 break;
-              case Poppler::FormFieldButton::Radio:       fieldType = "radio";           break;
+              case Poppler::FormFieldButton::Radio:
+                fieldType = "radio";
+                Nan::Set(obj, Nan::New<String>("caption").ToLocalChecked(), Nan::New<String>(myButton->caption().toStdString()).ToLocalChecked());
+                break;
             }
             break;
 


### PR DESCRIPTION
In some cases, the radio button caption value on a pdf is not the printed one and so is unknown to the user. Also, sometimes said caption has some special chars, that prevent the user from finding the value that she has to use when writing the pdf.

Now, the result of `read()` contains a `caption` property if the field type is ` 'radio'`