### PR TITLE
imgpdf improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ PDF Fill Form (**pdf-fill-form**) is Node.js native C++ library for filling PDF 
 Libary uses internally Poppler QT5 for PDF form reading and filling. Cairo is used for PDF creation from page images (when parameter { "save": "imgpdf" } is used). 
 ## Features
 
+* __NEW version 3.1.0__: Added feature allowing for parallelization of the imgpdf feature, also allows for settings scale and whether antialiasing should be used.
+
 * __NEW version 3.0.0__: Updated QT library to version 5 (by Rob Davarnia @robdvr). 
 
 * Version 2.0.0__: Updated nan library to version 2.4.0. Now __pdf-fill-form__ works also with all latest node.js versions. Tested using 0.12.0, v4.4.7, v5.2.0, v6.3.0, v6.8.0, v6.9.1
@@ -33,7 +35,7 @@ pdfFillForm.read('test.pdf')
 var pdfFillForm = require('pdf-fill-form');
 var fs = require('fs');
 
-pdfFillForm.write('test.pdf', { "myField": "myField fill value" }, { "save": "pdf" } )
+pdfFillForm.write('test.pdf', { "myField": "myField fill value" }, { "save": "pdf", 'cores': 4, 'scale': 0.2, 'antialias': true } )
 .then(function(result) {
 	fs.writeFile("test123.pdf", result, function(err) {
 		if(err) {

--- a/example.js
+++ b/example.js
@@ -6,7 +6,7 @@ var formFields = pdfFormFill.readSync('test.pdf');
 console.log(formFields);
 
 // Write fields
-pdfFormFill.writeAsync('test.pdf', { 'myField1': 'myField1 fill text' }, { 'save': 'imgpdf' }, function(err, result) {
+pdfFormFill.writeAsync('test.pdf', { 'myField1': 'myField1 fill text' }, { 'save': 'imgpdf', 'cores': 8, 'scale': 0.2, 'antialias': true }, function(err, result) {
   if (err) {
       return console.log(err);
   }

--- a/src/NodePoppler.h
+++ b/src/NodePoppler.h
@@ -13,13 +13,16 @@ struct WriteFieldsParams {
   string sourcePdfFileName;
   string saveFormat;
   map<string, string> fields;
+  int cores;
+  double scale_factor;
+  bool antialiasing;
 };
 
 NAN_METHOD(ReadSync);
 NAN_METHOD(WriteSync);
 
 WriteFieldsParams v8ParamsToCpp(const Nan::FunctionCallbackInfo<v8::Value>& args);
-QBuffer *writePdfFields(WriteFieldsParams params);
+QBuffer *writePdfFields(const struct WriteFieldsParams &params);
 
 // }
 


### PR DESCRIPTION
You can specify:
 * Number of cores in which the pages will be rendered in parallel
 * Scale the pages are rendered (1 = 72 dpi, 0.2 = 360 dpi)
 * Whether the render has antialias or not

Parallelizing the rendering saves some time (even not as much as one
would hope) since the saving back to pdf is still done one page after
the other.

Using antialias allows for decreasing the dpi while still getting a
reasonable enough quality.