### PR TITLE
Set radio button "value" to the poppler button state

### DIFF
--- a/src/NodePoppler.cc
+++ b/src/NodePoppler.cc
@@ -357,6 +357,7 @@ NAN_METHOD(ReadSync) {
               case Poppler::FormFieldButton::Radio:
                 fieldType = "radio";
                 Nan::Set(obj, Nan::New<String>("caption").ToLocalChecked(), Nan::New<String>(myButton->caption().toStdString()).ToLocalChecked());
+                Nan::Set(obj, Nan::New<String>("value").ToLocalChecked(), Nan::New<Boolean>(myButton->state()));
                 break;
             }
             break;


### PR DESCRIPTION
The problem was that was it was impossible to figure out which radio
button is selected when reading the pdf form.

The possible values for the radio button are true or false,
same as a checkbox.