### PR TITLE
Compile changes to make module compile on OSX

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -25,7 +25,7 @@
             "xcode_settings": {
                 'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
                 "OTHER_CFLAGS": [
-                    '-mmacosx-version-min=10.7',
+                    '-mmacosx-version-min=10.11',
                     '-std=c++11',
                     '-stdlib=libc++',                
                     "-fexceptions",

--- a/src/NodePoppler.cc
+++ b/src/NodePoppler.cc
@@ -16,9 +16,9 @@
 #include <QtCore/QFile>
 #include <QtGui/QImage>
 #include <QtCore/QMutex>
-#include <QRunnable>
-#include <QSemaphore>
-#include <QThreadPool>
+#include <QtCore/QRunnable>
+#include <QtCore/QSemaphore>
+#include <QtCore/QThreadPool>
 
 #include "NodePoppler.h"    // NOLINT(build/include)
 

--- a/src/NodePoppler.cc
+++ b/src/NodePoppler.cc
@@ -15,7 +15,7 @@
 #include <QtCore/QBuffer>
 #include <QtCore/QFile>
 #include <QtGui/QImage>
-#include <QMutex>
+#include <QtCore/QMutex>
 #include <QRunnable>
 #include <QSemaphore>
 #include <QThreadPool>


### PR DESCRIPTION
Prepended the Qt classes with QtCore and upped mmacosx-version-min in order to make this module compile on OSX. This needs testing on Unix and Windows systems.