### PR TITLE
Allow selecting pages to render for imgpdf

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ PDF Fill Form (**pdf-fill-form**) is Node.js native C++ library for filling PDF 
 Libary uses internally Poppler QT5 for PDF form reading and filling. Cairo is used for PDF creation from page images (when parameter { "save": "imgpdf" } is used). 
 ## Features
 
-* **NEW version 4.1.0** : Support for Node 10 (by @florianbepunkt)
+* Version v4.2.0: New options startPage and endPage for the imgpdf feature to limit which pages are generated.  Page numbers indexed from 0 (by Derick Naef @ochimo).
+
+* Version 4.1.0: Support for Node 10 (by @florianbepunkt)
 
 * Version 4.0.0: Added feature allowing for parallelization of the imgpdf feature, also allows for settings scale and whether antialiasing should be used (by Albert Astals Cid @tsdgeos).
 
@@ -138,7 +140,7 @@ I mostly recommand to install this package to have better support with fonts :
 $ sudo apt-get install poppler-data
 ```
 
-### Windows 
+### Windows
 
 Not currently supported
 
@@ -149,8 +151,11 @@ Not currently supported
 
 ## Changelog (from 24.5.2017 ->)
 
-v4.1.0 (10.9.2018) 
- - Support for Node 10 (by @florianbepunkt)
+v4.2.0 (x.x.x)
+- New options startPage and endPage for the imgpdf feature to limit which pages are generated.  Page numbers indexed from 0 (by Derick Naef @ochimo).
+
+v4.1.0 (10.9.2018)
+- Support for Node 10 (by @florianbepunkt)
 
 v4.0.0 (14.12.2017)
 - #45 Set radio button "value" to the poppler button state (by Albert Astals Cid @tsdgeos)
@@ -179,9 +184,10 @@ v3.2.0 (24.5.2017)
 - Mihai Saru @MitzaCoder
 - Albert Astals Cid @tsdgeos
 - Florian Bischoff @florianbepunkt
+- Derick Naef @ochimo
 
 ## License
 MIT  
 
-NOTE ABOUT LIBRARY DEPENDENCIES!   
+NOTE ABOUT LIBRARY DEPENDENCIES!
 *Poppler has* ***GPL*** *license.* Cairo has LGPL.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "qt5",
     "cairo"
   ],
-  "version": "4.1.0",
+  "version": "4.2.0",
   "repository": {
     "type": "git",
     "url": "git://github.com/tpisto/pdf-fill-form.git"

--- a/src/NodePoppler.h
+++ b/src/NodePoppler.h
@@ -16,6 +16,8 @@ struct WriteFieldsParams {
   int cores;
   double scale_factor;
   bool antialiasing;
+  int startPage;
+  int endPage;
 };
 
 NAN_METHOD(ReadSync);


### PR DESCRIPTION
These changes allows you to specify new parameters startPage and endPage when using imgpdf feature to only render the selected pages (pages are 0-indexed)