### PR TITLE
Allow source to come in a a buffer an not a filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,14 +177,18 @@ $ sudo apt-get install poppler-data
 
 ## Changelog (from 24.5.2017 ->)
 
-v3.2.0 (24.5.2017)
-- Support for radio buttons (by Matt Cherry @mttchrry)
+v4.1.0 (10.9.2018) 
+ - Support for Node 10 (by @florianbepunkt)
+
+v4.0.0 (14.12.2017)
+- #45 Set radio button "value" to the poppler button state (by Albert Astals Cid @tsdgeos)
+- Added feature allowing for parallelization of the imgpdf feature, also allows for settings scale and whether antialiasing should be used (by Albert Astals Cid @tsdgeos).
 
 v3.3.0 (14.12.2017)
 - #49 Set radio button "value" to the poppler button state (by Mihai Saru @MitzaCoder)
 
-v4.0.0 (14.12.2017)
-- #45 Set radio button "value" to the poppler button state (by Albert Astals Cid @tsdgeos)
+v3.2.0 (24.5.2017)
+- Support for radio buttons (by Matt Cherry @mttchrry)
 
 ## Authors
 - [Tommi Pisto](https://github.com/tpisto)

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Libary uses internally Poppler QT5 for PDF form reading and filling. Cairo is us
 
 ## Examples
 ### Using promises
+Read from file
 ```javascript
 var pdfFillForm = require('pdf-fill-form');
 
@@ -33,6 +34,20 @@ pdfFillForm.read('test.pdf')
 	console.log(err);
 });
 ```
+
+Read from file buffer
+```javascript
+var pdfFillForm = require('pdf-fill-form');
+
+pdfFillForm.readBuffer(fs.readFileSync('test.pdf'))
+.then(function(result) {
+    console.log(result);
+}, function(err) {
+	console.log(err);
+});
+```
+
+Write from file
 ```javascript
 var pdfFillForm = require('pdf-fill-form');
 var fs = require('fs');
@@ -48,7 +63,24 @@ pdfFillForm.write('test.pdf', { "myField": "myField fill value" }, { "save": "pd
 }, function(err) {
   	console.log(err);
 });
+```
 
+Write from file buffer
+```javascript
+var pdfFillForm = require('pdf-fill-form');
+var fs = require('fs');
+
+pdfFillForm.writeBuffer(fs.readFileSync('test.pdf'), { "myField": "myField fill value" }, { "save": "pdf", 'cores': 4, 'scale': 0.2, 'antialias': true } )
+.then(function(result) {
+	fs.writeFile("test123.pdf", result, function(err) {
+		if(err) {
+	   		return console.log(err);
+	   	}
+	   	console.log("The file was saved!");
+	}); 
+}, function(err) {
+  	console.log(err);
+});
 ```
 ### Using callbacks
 To **read** all form fields:  
@@ -138,10 +170,6 @@ I mostly recommand to install this package to have better support with fonts :
 $ sudo apt-get install poppler-data
 ```
 
-### Windows 
-
-Not currently supported
-
 ## Todo
 * Tests
 * Refactoring
@@ -149,18 +177,14 @@ Not currently supported
 
 ## Changelog (from 24.5.2017 ->)
 
-v4.1.0 (10.9.2018) 
- - Support for Node 10 (by @florianbepunkt)
-
-v4.0.0 (14.12.2017)
-- #45 Set radio button "value" to the poppler button state (by Albert Astals Cid @tsdgeos)
-- Added feature allowing for parallelization of the imgpdf feature, also allows for settings scale and whether antialiasing should be used (by Albert Astals Cid @tsdgeos).
+v3.2.0 (24.5.2017)
+- Support for radio buttons (by Matt Cherry @mttchrry)
 
 v3.3.0 (14.12.2017)
 - #49 Set radio button "value" to the poppler button state (by Mihai Saru @MitzaCoder)
 
-v3.2.0 (24.5.2017)
-- Support for radio buttons (by Matt Cherry @mttchrry)
+v4.0.0 (14.12.2017)
+- #45 Set radio button "value" to the poppler button state (by Albert Astals Cid @tsdgeos)
 
 ## Authors
 - [Tommi Pisto](https://github.com/tpisto)

--- a/lib/pdf-fill-form.js
+++ b/lib/pdf-fill-form.js
@@ -9,7 +9,33 @@
                 try {
                     var myFile = myLib.readSync(fileName);
                     resolve(myFile);
-                } 
+                }
+                catch(error) {
+                    reject(error);
+                }
+            });
+        }
+
+        // ReadBuffer promise (sync)
+        myLib.readBuffer = function(fileBuffer) {
+            return new Promise(function(resolve, reject) {
+                try {
+                    var myFile = myLib.readBufferSync(fileBuffer);
+                    resolve(myFile);
+                }
+                catch(error) {
+                    reject(error);
+                }
+            });
+        }
+
+        // WriteBuffer promise (sync)
+        myLib.writeBuffer = function(fileBuffer, fields, params) {
+            return new Promise(function(resolve, reject) {
+                try {
+                    var myFile = myLib.writeBufferSync(fileBuffer, fields, params);
+                    resolve(myFile);
+                }
                 catch(error) {
                     reject(error);
                 }
@@ -26,12 +52,13 @@
                             resolve(result);
                         }
                     });
-                } 
+                }
                 catch(error) {
                     reject(error);
                 }
             });
-        }        
+        }
+
 
         return myLib;
     }

--- a/src/NodePoppler.cc
+++ b/src/NodePoppler.cc
@@ -204,16 +204,27 @@ void createImgPdf(QBuffer *buffer, Poppler::Document *document, const struct Wri
   cairo_surface_destroy (surface);
 }
 
-WriteFieldsParams v8ParamsToCpp(const Nan::FunctionCallbackInfo<v8::Value>& args) {
+WriteFieldsParams v8ParamsToCpp(const Nan::FunctionCallbackInfo<v8::Value>& args, bool isBuffer) {
   Local<Object> parameters;
   string saveFormat = "imgpdf";
   map<string, string> fields;
   int nCores = 1;
   double scale_factor = 0.2;
   bool antialiasing = false;
+  string sourcePdfFileName = "";
+  QByteArray sourceBuffer;
 
-  String::Utf8Value sourcePdfFileNameParam(args[0]->ToString());
-  string sourcePdfFileName = string(*sourcePdfFileNameParam);
+  if(isBuffer) {
+    Local<Object> bufferObj = args[0]->ToObject();
+    char* bufferData = node::Buffer::Data(bufferObj);
+    size_t bufferLength = node::Buffer::Length(bufferObj);
+
+
+    sourceBuffer = sourceBuffer.append(bufferData, bufferLength);
+  } else {
+    String::Utf8Value sourcePdfFileNameParam(args[0]->ToString());
+    sourcePdfFileName = string(*sourcePdfFileNameParam);
+  }
 
   Local<Object> changeFields = args[1]->ToObject();
 
@@ -260,24 +271,35 @@ WriteFieldsParams v8ParamsToCpp(const Nan::FunctionCallbackInfo<v8::Value>& args
   params.cores = nCores;
   params.scale_factor = scale_factor;
   params.antialiasing = antialiasing;
+  params.sourceBuffer = sourceBuffer;
   return params;
 }
 
 // Pdf creator that is not dependent on V8 internals (safe at async?)
-QBuffer *writePdfFields(const struct WriteFieldsParams &params) {
+QBuffer *writePdfFields(const struct WriteFieldsParams &params, bool isBuffer) {
 
   ostringstream ss;
-  // If source file does not exist, throw error and return false
-  if (!fileExists(params.sourcePdfFileName)) {
-    ss << "File \"" << params.sourcePdfFileName << "\" does not exist";
-    throw ss.str();
-  }
+  Poppler::Document *document;
 
-  // Open document and return false and throw error if something goes wrong
-  Poppler::Document *document = Poppler::Document::load(QString::fromStdString(params.sourcePdfFileName));
-  if (document == NULL) {
-    ss << "Error occurred when reading \"" << params.sourcePdfFileName << "\"";
-    throw ss.str();
+  if(isBuffer) {
+    document = Poppler::Document::loadFromData(params.sourceBuffer);
+    if (document == NULL) {
+      ss << "Error occurred when reading buffer";
+      throw ss.str();
+    }
+  } else {
+    // If source file does not exist, throw error and return false
+    if (!fileExists(params.sourcePdfFileName)) {
+      ss << "File \"" << params.sourcePdfFileName << "\" does not exist";
+      throw ss.str();
+    }
+
+    // Open document and return false and throw error if something goes wrong
+    document = Poppler::Document::load(QString::fromStdString(params.sourcePdfFileName));
+    if (document == NULL) {
+      ss << "Error occurred when reading \"" << params.sourcePdfFileName << "\"";
+      throw ss.str();
+    }
   }
 
   // Fill form
@@ -371,41 +393,8 @@ QBuffer *writePdfFields(const struct WriteFieldsParams &params) {
   return bufferDevice;
 }
 
-
-//***********************************
-//
-// Node.js methods
-//
-//***********************************
-
-// Read PDF form fields
-NAN_METHOD(ReadSync) {
-
-  // expect a number as the first argument
-  Nan::Utf8String *fileName = new Nan::Utf8String(info[0]);
-  ostringstream ss;
-  int n = 0;
-
-  // If file does not exist, throw error and return false
-  if (!fileExists(**fileName)) {
-    ss << "File \"" << **fileName << "\" does not exist";
-    Nan::ThrowError(Nan::New<String>(ss.str()).ToLocalChecked());
-    info.GetReturnValue().Set(Nan::False());
-  }
-
-  // Open document and return false and throw error if something goes wrong
-  Poppler::Document *document = Poppler::Document::load(**fileName);
-  if (document != NULL) {
-    // Get field list
-    n = document->numPages();
-  } else {
-    ss << "Error occurred when reading \"" << **fileName << "\"";
-    Nan::ThrowError(Nan::New<String>(ss.str()).ToLocalChecked());
-    info.GetReturnValue().Set(Nan::False());
-  }
-
-  delete fileName;
-
+Local<Array> readPdfFields(Poppler::Document *document) {
+  int n = document->numPages();
   // Store field value objects to v8 array
   Local<Array> fieldArray = Nan::New<Array>();
   int fieldNum = 0;
@@ -493,7 +482,71 @@ NAN_METHOD(ReadSync) {
     delete page;
   }
 
-  info.GetReturnValue().Set(fieldArray);
+  return fieldArray;
+}
+
+//***********************************
+//
+// Node.js methods
+//
+//***********************************
+
+// Read PDF form fields
+NAN_METHOD(ReadBufferSync) {
+  Local<Object> bufferObj = info[0]->ToObject();
+  char* bufferData = node::Buffer::Data(bufferObj);
+  size_t bufferLength = node::Buffer::Length(bufferObj);
+
+  ostringstream ss;
+  int n = 0;
+
+  QByteArray buffer;
+  buffer = buffer.append(bufferData, bufferLength);
+  Poppler::Document *document = Poppler::Document::loadFromData(buffer);
+
+  if (document != NULL) {
+    // Get field list
+    n = document->numPages();
+  } else {
+    ss << "Error occurred when reading buffer\"";
+    Nan::ThrowError(Nan::New<String>(ss.str()).ToLocalChecked());
+    info.GetReturnValue().Set(Nan::False());
+  }
+
+  info.GetReturnValue().Set(readPdfFields(document));
+
+  delete document;
+}
+
+// Read PDF form fields
+NAN_METHOD(ReadSync) {
+
+  // expect a number as the first argument
+  Nan::Utf8String *fileName = new Nan::Utf8String(info[0]);
+  ostringstream ss;
+  int n = 0;
+
+  // If file does not exist, throw error and return false
+  if (!fileExists(**fileName)) {
+    ss << "File \"" << **fileName << "\" does not exist";
+    Nan::ThrowError(Nan::New<String>(ss.str()).ToLocalChecked());
+    info.GetReturnValue().Set(Nan::False());
+  }
+
+  // Open document and return false and throw error if something goes wrong
+  Poppler::Document *document = Poppler::Document::load(**fileName);
+  if (document != NULL) {
+    // Get field list
+    n = document->numPages();
+  } else {
+    ss << "Error occurred when reading \"" << **fileName << "\"";
+    Nan::ThrowError(Nan::New<String>(ss.str()).ToLocalChecked());
+    info.GetReturnValue().Set(Nan::False());
+  }
+
+  delete fileName;
+
+  info.GetReturnValue().Set(readPdfFields(document));
 
   delete document;
 }
@@ -508,6 +561,28 @@ NAN_METHOD(WriteSync) {
   try
   {
     QBuffer *buffer = writePdfFields(params);
+    Local<Object> returnPdf = Nan::CopyBuffer((char *)buffer->data().data(), buffer->size()).ToLocalChecked();
+    buffer->close();
+    delete buffer;
+    info.GetReturnValue().Set(returnPdf);
+  }
+  catch (string error)
+  {
+    Nan::ThrowError(Nan::New<String>(error).ToLocalChecked());
+    info.GetReturnValue().Set(Nan::Null());
+  }
+}
+
+// Write PDF form fields
+NAN_METHOD(WriteBufferSync) {
+
+  // Check and return parameters given at JavaScript function call
+  WriteFieldsParams params = v8ParamsToCpp(info, true);
+
+  // Create and return pdf
+  try
+  {
+    QBuffer *buffer = writePdfFields(params, true);
     Local<Object> returnPdf = Nan::CopyBuffer((char *)buffer->data().data(), buffer->size()).ToLocalChecked();
     buffer->close();
     delete buffer;

--- a/src/NodePoppler.h
+++ b/src/NodePoppler.h
@@ -11,6 +11,7 @@ using namespace std;
 struct WriteFieldsParams {
   WriteFieldsParams(string a, string b, map<string,string> c) : sourcePdfFileName(a), saveFormat(b), fields(c){}
   string sourcePdfFileName;
+  QByteArray sourceBuffer;
   string saveFormat;
   map<string, string> fields;
   int cores;
@@ -19,10 +20,12 @@ struct WriteFieldsParams {
 };
 
 NAN_METHOD(ReadSync);
+NAN_METHOD(ReadBufferSync);
 NAN_METHOD(WriteSync);
+NAN_METHOD(WriteBufferSync);
 
-WriteFieldsParams v8ParamsToCpp(const Nan::FunctionCallbackInfo<v8::Value>& args);
-QBuffer *writePdfFields(const struct WriteFieldsParams &params);
+WriteFieldsParams v8ParamsToCpp(const Nan::FunctionCallbackInfo<v8::Value>& args, bool isBuffer = false);
+QBuffer *writePdfFields(const struct WriteFieldsParams &params, bool isBuffer = false);
 
 // }
 

--- a/src/pdf-fill-form.cc
+++ b/src/pdf-fill-form.cc
@@ -10,8 +10,14 @@ NAN_MODULE_INIT(InitAll) {
   Nan::Set(target, Nan::New("readSync").ToLocalChecked(),
     Nan::GetFunction(Nan::New<FunctionTemplate>(ReadSync)).ToLocalChecked());
 
+  Nan::Set(target, Nan::New("readBufferSync").ToLocalChecked(),
+    Nan::GetFunction(Nan::New<FunctionTemplate>(ReadBufferSync)).ToLocalChecked());
+
   Nan::Set(target, Nan::New("writeSync").ToLocalChecked(),
     Nan::GetFunction(Nan::New<FunctionTemplate>(WriteSync)).ToLocalChecked());
+
+  Nan::Set(target, Nan::New("writeBufferSync").ToLocalChecked(),
+    Nan::GetFunction(Nan::New<FunctionTemplate>(WriteBufferSync)).ToLocalChecked());
 
   Nan::Set(target, Nan::New("writeAsync").ToLocalChecked(),
     Nan::GetFunction(Nan::New<FunctionTemplate>(WriteAsync)).ToLocalChecked());


### PR DESCRIPTION
This adds Sync methods for reading and writing using a stream buffer as the source.  The first param for each is the stream buffer which can be accessed via `rs.readFileSync()`

``` 
await PdfFillForm.readBuffer(fs.readFileSync('test.pdf'));
```

```
await PdfFillForm.writeBuffer(fs.readFileSync('test.pdf'), { "myField": "myField fill value" }, { "save": "pdf", 'cores': 4, 'scale': 0.2, 'antialias': true } );
```