### PR TITLE
Use different BooleanValue() method depending on node version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # osx noise
 .DS_Store
 profile
+.idea
 
 # xcode noise
 build/*

--- a/src/NodePoppler.cc
+++ b/src/NodePoppler.cc
@@ -216,7 +216,7 @@ void createImgPdf(QBuffer *buffer, Poppler::Document *document, const struct Wri
 
 WriteFieldsParams v8ParamsToCpp(const Nan::FunctionCallbackInfo<v8::Value>& args, bool isBuffer) {
   Isolate* isolate = args.GetIsolate();
-  
+
   Local<Object> parameters;
   string saveFormat = "imgpdf";
   map<string, string> fields;
@@ -270,7 +270,11 @@ WriteFieldsParams v8ParamsToCpp(const Nan::FunctionCallbackInfo<v8::Value>& args
 
     Local<Value> antialiasParam = Nan::Get(parameters, antialiasStr).ToLocalChecked();
     if (antialiasParam->IsBoolean()) {
+      #if (NODE_MODULE_VERSION > NODE_11_0_MODULE_VERSION)
       antialiasing = antialiasParam->BooleanValue(isolate);
+      #else
+      antialiasing = antialiasParam->BooleanValue(isolate->GetCurrentContext()).ToChecked();
+      #endif
     }
 
     Local<Value> startPageParam = Nan::Get(parameters, startPageStr).ToLocalChecked();


### PR DESCRIPTION
The current code base does not compile on node 10 due to the required Isolate param in the BooleanValue call.  This adds and ifdef around that call to make this work with Node 10.